### PR TITLE
Fixed Router#Find panic an infinite loop

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -508,6 +508,40 @@ func TestContextGetAndSetParam(t *testing.T) {
 	})
 }
 
+// Issue #1655
+func TestContextSetParamNamesShouldUpdateEchoMaxParam(t *testing.T) {
+	assert := testify.New(t)
+
+	e := New()
+	assert.Equal(0, *e.maxParam)
+
+	expectedOneParam := []string{"one"}
+	expectedTwoParams := []string{"one", "two"}
+	expectedThreeParams := []string{"one", "two", ""}
+	expectedABCParams := []string{"A", "B", "C"}
+
+	c := e.NewContext(nil, nil)
+	c.SetParamNames("1", "2")
+	c.SetParamValues(expectedTwoParams...)
+	assert.Equal(2, *e.maxParam)
+	assert.EqualValues(expectedTwoParams, c.ParamValues())
+
+	c.SetParamNames("1")
+	assert.Equal(2, *e.maxParam)
+	// Here for backward compatibility the ParamValues remains as they are
+	assert.EqualValues(expectedOneParam, c.ParamValues())
+
+	c.SetParamNames("1", "2", "3")
+	assert.Equal(3, *e.maxParam)
+	// Here for backward compatibility the ParamValues remains as they are, but the len is extended to e.maxParam
+	assert.EqualValues(expectedThreeParams, c.ParamValues())
+
+	c.SetParamValues("A", "B", "C", "D")
+	assert.Equal(3, *e.maxParam)
+	// Here D shouldn't be returned
+	assert.EqualValues(expectedABCParams, c.ParamValues())
+}
+
 func TestContextFormValue(t *testing.T) {
 	f := make(url.Values)
 	f.Set("name", "Jon Snow")

--- a/router_test.go
+++ b/router_test.go
@@ -1298,6 +1298,43 @@ func TestRouterParam1466(t *testing.T) {
 	assert.Equal(t, 0, c.response.Status)
 }
 
+// Issue #1655
+func TestRouterFindNotPanicOrLoopsWhenContextSetParamValuesIsCalledWithLessValuesThanEchoMaxParam(t *testing.T) {
+	e := New()
+	r := e.router
+
+	v0 := e.Group("/:version")
+	v0.GET("/admin", func(c Context) error {
+		c.SetParamNames("version")
+		c.SetParamValues("v1")
+		return nil
+	})
+
+	v0.GET("/images/view/:id", handlerHelper("iv", 1))
+	v0.GET("/images/:id", handlerHelper("i", 1))
+	v0.GET("/view/*", handlerHelper("v", 1))
+
+	//If this API is called before the next two one panic the other loops ( of course without my fix ;) )
+	c := e.NewContext(nil, nil)
+	r.Find(http.MethodGet, "/v1/admin", c)
+	c.Handler()(c)
+	assert.Equal(t, "v1", c.Param("version"))
+
+	//panic
+	c = e.NewContext(nil, nil)
+	r.Find(http.MethodGet, "/v1/view/same-data", c)
+	c.Handler()(c)
+	assert.Equal(t, "same-data", c.Param("*"))
+	assert.Equal(t, 1, c.Get("v"))
+
+	//looping
+	c = e.NewContext(nil, nil)
+	r.Find(http.MethodGet, "/v1/images/view", c)
+	c.Handler()(c)
+	assert.Equal(t, "view", c.Param("id"))
+	assert.Equal(t, 1, c.Get("i"))
+}
+
 func benchmarkRouterRoutes(b *testing.B, routes []*Route) {
 	e := New()
 	r := e.router


### PR DESCRIPTION
Before this fix, Router#Find panics or enters in an infinite loop when
the context params values were set to a number less than the max number
of params supported by the Router.